### PR TITLE
Add support for requests authentication methods in downloads

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,14 +9,36 @@ File downloads can be interrupted and continued later.
 
 Downloading files:
 ```python
-
 from url_downloader import save_file
 save_file(url='https://example.url/image.jpg', file_path='C:\\path', file_name='name.jpg')
 ```
 
+With HTTP authentication:
+
+```python
+from url_downloader import save_file
+from requests.auth import HTTPDigestAuth
+
+myauth = HTTPDigestAuth('username', 'password')
+
+save_file(url='https://example.url/image.jpg', file_path='C:\\path', file_name='name.jpg', auth=myauth)
+```
+
 Retrieving text data:
 ```python
-
 from url_downloader import get_resource
 data = get_resource(url='https://example.url/')
 ```
+
+With HTTP authentication:
+```python
+from url_downloader import get_resource
+from requests.auth import HTTPDigestAuth
+
+myauth = HTTPDigestAuth('username', 'password')
+
+data = get_resource(url='https://example.url/', auth=myauth)
+```
+
+
+

--- a/url_downloader/url_downloader.py
+++ b/url_downloader/url_downloader.py
@@ -1,12 +1,14 @@
 """
 Simple download from url
 """
+from typing import Optional
 from logging import info, exception, error
 from shutil import move
 from tempfile import gettempdir
 from time import sleep
 from hashlib import sha224
 from requests import get
+from requests.auth import AuthBase
 from pathlib import Path
 from re import findall
 
@@ -15,10 +17,12 @@ class SaveToDisk:
     """
     Override requests.get to save file to target path
     """
-
     def __init__(self, file_path: Path, url: str):
         # Prevent name collisions by using hash
-        self._temp_path = Path(gettempdir(), sha224(bytes(url, encoding='UTF-8')).hexdigest() + file_path.suffix)
+        self._temp_path = Path(
+            gettempdir(),
+            sha224(bytes(url, encoding='UTF-8')).hexdigest() +
+            file_path.suffix)
         self._file_path = file_path
 
     def _move_temporary(self, url: str) -> bool:
@@ -35,24 +39,35 @@ class SaveToDisk:
         info("DOWNLOADED: %s TO %s" % (url, self._file_path))
         return True
 
-    def get(self, url: str, headers: dict, timeout: int) -> bool:
+    def get(self,
+            url: str,
+            headers: dict,
+            timeout: int,
+            auth: Optional[AuthBase] = None) -> bool:
         """
         Function replaces requests.get so the url content is also saved as a file.
         Cancelling and resuming download is supported.
         :param url: Content url
         :param headers: Headers for response.get
         :param timeout: Timeout for response.get
+        :param auth: Instance of authentication class from requests
         :return: True, if download was successful, or file already exists.
         """
         # '''http://masnun.com/2016/09/18/python-using-the-requests-module-to-download-large-files-efficiently.html'''
         # Get html stream
-        resume_byte_pos = self._temp_path.stat().st_size if self._temp_path.exists() else 0
+        resume_byte_pos = self._temp_path.stat(
+        ).st_size if self._temp_path.exists() else 0
 
         # Add range header for resuming the download
         headers['Range'] = 'bytes=%d-' % resume_byte_pos
-        response = get(url, headers=headers, stream=True, timeout=timeout)
+        response = get(url,
+                       headers=headers,
+                       stream=True,
+                       timeout=timeout,
+                       auth=auth)
         if response.status_code not in (200, 206):
-            info('Wrong http response %s %s' % (response.status_code, response.text))
+            info('Wrong http response %s %s' %
+                 (response.status_code, response.text))
             return False
 
         # Save to temporary file
@@ -64,7 +79,12 @@ class SaveToDisk:
         return self._move_temporary(url)
 
 
-def _get_url_data(url: str, get_function: callable, tries: int, timeout: int, wait: int):
+def _get_url_data(url: str,
+                  get_function: callable,
+                  tries: int,
+                  timeout: int,
+                  wait: int,
+                  auth: Optional[AuthBase] = None):
     """
     Download the URL's content
     :param url: Content url
@@ -72,13 +92,17 @@ def _get_url_data(url: str, get_function: callable, tries: int, timeout: int, wa
     :param tries: Number of retries, if the download failed
     :param timeout: Response.get timeout in seconds
     :param wait: Wait time before download starts (in seconds)
+    :param auth: Instance of authentication class from requests
     :return: None, if download failed, or return value of the get_function
     """
     # Try download until it succeeds
     for i in range(wait, tries):
         try:
             sleep(i)  # Wait time to prevent accidental DOS
-            result = get_function(url, headers={'User-agent': 'Chrome'}, timeout=timeout)
+            result = get_function(url,
+                                  headers={'User-agent': 'Chrome'},
+                                  timeout=timeout,
+                                  auth=auth)
             if result:
                 return result
         except ConnectionError as e:
@@ -103,8 +127,14 @@ def _get_file_name(url: str) -> str:
     return url.split('/')[-1]
 
 
-def save_file(url: str, file_path: str, file_name: str = '', timeout: int = 4, wait: int = 2, tries: int = 10,
-              save_class: callable = SaveToDisk) -> bool:
+def save_file(url: str,
+              file_path: str,
+              file_name: str = '',
+              timeout: int = 4,
+              wait: int = 2,
+              tries: int = 10,
+              save_class: callable = SaveToDisk,
+              auth: Optional[AuthBase] = None) -> bool:
     """
     Download file and save to disk.
     :param url: Url of the file
@@ -114,6 +144,7 @@ def save_file(url: str, file_path: str, file_name: str = '', timeout: int = 4, w
     :param wait: Wait time before download starts (in seconds)
     :param tries: Number of download tries
     :param save_class: Class to manage saving file
+    :param auth: Instance of authentication class from requests
     :return: True, if download successful or file already exists, False otherwise
     """
     if not file_name:
@@ -124,20 +155,36 @@ def save_file(url: str, file_path: str, file_name: str = '', timeout: int = 4, w
         info('File exists %s' % file_name)
         return True
 
-    return _get_url_data(url, save_class(file_path=path, url=url).get, tries=tries, timeout=timeout, wait=wait)
+    return _get_url_data(url,
+                         save_class(file_path=path, url=url).get,
+                         tries=tries,
+                         timeout=timeout,
+                         wait=wait,
+                         auth=auth)
 
 
-def get_resource(url: str, timeout: int = 4, wait: int = 2, tries: int = 10, get_function: callable = get) -> str:
+def get_resource(url: str,
+                 timeout: int = 4,
+                 wait: int = 2,
+                 tries: int = 10,
+                 auth: Optional[AuthBase] = None,
+                 get_function: callable = get) -> str:
     """
     Get web resource as a string.
     :param url: Url of the file
     :param timeout: Response timeout in seconds
     :param wait: Wait time before download starts (in seconds)
     :param tries: Number of download tries
+    :param auth: Instance of authentication class from requests
     :param get_function: requests.get or custom function
     :return: Resource as a string
     """
-    data = _get_url_data(url, get_function, tries=tries, timeout=timeout, wait=wait)
+    data = _get_url_data(url,
+                         get_function,
+                         tries=tries,
+                         timeout=timeout,
+                         wait=wait,
+                         auth=auth)
     if data:
         return data.text
     return data


### PR DESCRIPTION
This is a small patch that allows to pass [requests authentication information](https://requests.readthedocs.io/en/latest/user/authentication/) to the methods of the library. It allows to download find behind authentication.